### PR TITLE
Optional depth argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ The `s3tree` accepts two options:
 - `bucket` - Obligatory. The S3 bucket name
 - `s3` - Optional. The `aws-sdk` S3 class instance. For example: `new AWS.S3({apiVersion: '2006-03-01')`
 
-The `s3tree.generate(path)` function takes:
+The `s3tree.generate(path, depth)` function takes:
 
 - `path` - any string. E.g.
   - `"/"`, `""`, or
   - `"/folder"`, `"folder/"`, `"folder"`, or
   - `"/1/2/3/4"`, `"1/2/3/4/"`, `"1/2/3/4"`, etc.
+- `depth` - Optional. The number of folders deep to traverse and generate. 0 will return only the direct contents of the folder.
 
 and returns a Promise.
 

--- a/index.js
+++ b/index.js
@@ -19,16 +19,21 @@ module.exports = function(options) {
         tree[getLastPathPart(file)] = file;
       });
 
-      if (!data.folders || !data.folders.length || depth === 0) return Promise.resolve(tree);
+      if (!data.folders || !data.folders.length) return Promise.resolve(tree);
 
       const reducedDepth = (typeof depth === 'number' && depth > 0) ? depth - 1 : depth;
 
       return Promise.all(
-        data.folders.map(path =>
-          generate(path, reducedDepth).then(result => {
+        data.folders.map(path => {
+          if (depth === 0) {
+            tree[getLastPathPart(path)] = {};
+            return Promise.resolve();
+          }
+
+          return generate(path, reducedDepth).then(result => {
             tree[getLastPathPart(path)] = result;
-          })
-        )
+          });
+        })
       ).then(() => tree);
     });
   }

--- a/index.js
+++ b/index.js
@@ -12,18 +12,20 @@ function getLastPathPart(path) {
 module.exports = function(options) {
   const lister = s3ls(options);
 
-  function generate(folder) {
+  function generate(folder, depth) {
     return lister.ls(folder).then(data => {
       const tree = {};
       data.files.forEach(file => {
         tree[getLastPathPart(file)] = file;
       });
 
-      if (!data.folders || !data.folders.length) return Promise.resolve(tree);
+      if (!data.folders || !data.folders.length || depth === 0) return Promise.resolve(tree);
+
+      const reducedDepth = (typeof depth === 'number' && depth > 0) ? depth - 1 : depth;
 
       return Promise.all(
         data.folders.map(path =>
-          generate(path).then(result => {
+          generate(path, reducedDepth).then(result => {
             tree[getLastPathPart(path)] = result;
           })
         )

--- a/index.js
+++ b/index.js
@@ -21,14 +21,14 @@ module.exports = function(options) {
 
       if (!data.folders || !data.folders.length) return Promise.resolve(tree);
 
-      const reducedDepth = (typeof depth === 'number' && depth > 0) ? depth - 1 : depth;
-
       return Promise.all(
         data.folders.map(path => {
           if (depth === 0) {
             tree[getLastPathPart(path)] = {};
             return Promise.resolve();
           }
+
+          const reducedDepth = (typeof depth === 'number' && depth > 0) ? depth - 1 : depth;
 
           return generate(path, reducedDepth).then(result => {
             tree[getLastPathPart(path)] = result;

--- a/test/index.js
+++ b/test/index.js
@@ -242,4 +242,31 @@ test("should accept depth as an optional argument for generate", t => {
     })
     .catch(st.end);
   });
+
+  t.test("should ignore if depth is negative", st => {
+    st.plan(5);
+    const s3tree = getProxyQuire(st);
+
+    s3tree()
+    .generate("/", -1)
+    .then(tree => {
+      st.deepEqual(tree, {
+        file1: "file1",
+        file2: "file2",
+        folder: {
+          file3: "folder/file3",
+          file4: "folder/file4",
+          "sub-folder": {
+            file5: "folder/sub-folder/file5",
+            file6: "folder/sub-folder/file6",
+            "sub-sub-folder": {
+              file7: "folder/sub-folder/sub-sub-folder/file7",
+              file8: "folder/sub-folder/sub-sub-folder/file8"
+            }
+          }
+        }
+      });
+    })
+    .catch(st.end);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -188,6 +188,7 @@ test("should accept depth as an optional argument for generate", t => {
         st.deepEqual(tree, {
           file1: "file1",
           file2: "file2",
+          folder: {}
         });
       })
       .catch(st.end);
@@ -209,6 +210,7 @@ test("should accept depth as an optional argument for generate", t => {
             "sub-folder": {
               file5: "folder/sub-folder/file5",
               file6: "folder/sub-folder/file6",
+              "sub-sub-folder": {}
             }
           }
       });


### PR DESCRIPTION
I was looking at this package, and thought an optional depth argument on the generate function might be useful. It allows the code to specify how many folders deep the tree should traverse when generate is called, preventing any extra API calls to S3.

For example, if you had the following file structure:
```
{
  file1: "file1",
  file2: "file2",
  folder: {
    file3: "folder/file3",
    file4: "folder/file4",
    "sub-folder": {
      file5: "folder/sub-folder/file5",
      file6: "folder/sub-folder/file6",
      "sub-sub-folder": {
        file7: "folder/sub-folder/sub-sub-folder/file7",
        file8: "folder/sub-folder/sub-sub-folder/file8"
       }
    }
}
```

A specified depth of 0 here would return:
```
{
  file1: "file1",
  file2: "file2",
  folder: {}
}
```

A specified depth of 2 here would return:
```
{
  file1: "file1",
  file2: "file2",
  folder: {
    file3: "folder/file3",
    file4: "folder/file4",
    "sub-folder": {
      file5: "folder/sub-folder/file5",
      file6: "folder/sub-folder/file6",
      "sub-sub-folder": {}
    }
}
```

A specified depth here of 3 or greater, a negative number, or not passing in the depth prop would return the whole tree.

Anyway, let me know what you think, as it seems like a cheap and useful way to reduce the s3 call count when the complete tree is not needed.